### PR TITLE
fix: add CLAUDE.md loading instruction to agent prompt generation

### DIFF
--- a/agentic-development/scripts/setup-agent-task.sh
+++ b/agentic-development/scripts/setup-agent-task.sh
@@ -442,6 +442,7 @@ I am the $(echo "$AGENT_NAME" | sed 's/-/ /g' | sed 's/\b\w/\U&/g') $GITHUB_ISSU
 Context Loading:
 - Load: .claude/agents/$(echo "$AGENT_NAME").md
 - Load: Implementation reports and workflow documentation
+- Load: CLAUDE.md (critical branch targeting and safety rules)
 EOF
 
 # Add context file loading if provided


### PR DESCRIPTION
## Summary
- Fixed agent prompt generation in setup-agent-task.sh to include CLAUDE.md loading instruction
- Ensures all generated agent prompts load critical branch targeting and safety rules
- Prevents agents from creating PRs that target main instead of dev branch

## Changes Made
- Modified `agentic-development/scripts/setup-agent-task.sh:445` 
- Added `- Load: CLAUDE.md (critical branch targeting and safety rules)` to Context Loading section

## Test Plan
- [x] Tested prompt generation with modified script
- [x] Verified CLAUDE.md loading instruction appears in generated prompts  
- [x] Confirmed backward compatibility maintained

## Impact
This fix ensures all future agents will receive critical workflow context including:
- Proper branch targeting rules (feature → dev, not main)
- 5-branch strategy compliance requirements
- Safety protocols and git workflow guidelines

Resolves #143

🤖 Generated with [Claude Code](https://claude.ai/code)