### PR TITLE
feat: enhance iTerm window naming with issue numbers

### DIFF
--- a/agentic-development/scripts/setup-agent-task.sh
+++ b/agentic-development/scripts/setup-agent-task.sh
@@ -552,7 +552,7 @@ elif [[ "$OSTYPE" == "darwin"* ]] && command -v osascript &>/dev/null; then
 tell application \"iTerm\"
     create window with default profile
     tell current session of current window
-        set name to \"$AGENT_NAME Agent\"
+        set name to \"$AGENT_NAME #$GITHUB_ISSUE\"
         write text \"cd \\\"$WORKTREE_PATH\\\"\"
         write text \"cat \\\"$PROMPT_FILE\\\"\"
         write text \"claude\"


### PR DESCRIPTION
## Summary
- Update shell scripts to use 'agent-name issue-number' format for persistent window names
- Modified setup-agent-task.sh AppleScript to include GitHub issue number in window names
- Window names now display as 'vibe-coder #247' instead of 'vibe-coder Agent'

## Test plan
- [x] Syntax validation passed with `bash -n`
- [x] Variable availability confirmed (GITHUB_ISSUE is set before AppleScript execution)
- [x] Implementation follows exact requested format from issue #247
- [ ] Manual testing in actual iTerm environment (recommended)

🤖 Generated with [Claude Code](https://claude.ai/code)