### PR TITLE
fix: correct argument passing in setup-agent-task-desktop.sh

### DIFF
--- a/agentic-development/scripts/setup-agent-task-desktop.sh
+++ b/agentic-development/scripts/setup-agent-task-desktop.sh
@@ -209,8 +209,26 @@ export CLAUDE_DESKTOP_MODE=true
 export SKIP_ITERM_AUTOMATION=true
 export SKIP_GITHUB_ISSUE_CREATION=true
 
-# Run the core script with all provided arguments
-"$CORE_SCRIPT" "$@"
+# Run the core script with the properly reconstructed arguments
+# Build the arguments array
+CORE_ARGS=("$AGENT_NAME" "$TASK_TITLE" "$TASK_DESCRIPTION")
+
+# Add context file if provided
+if [[ -n "$CONTEXT_FILE" ]]; then
+    CORE_ARGS+=("$CONTEXT_FILE")
+fi
+
+# Add optional arguments
+if [[ -n "$FILES_TO_EXAMINE" ]]; then
+    CORE_ARGS+=("--files=$FILES_TO_EXAMINE")
+fi
+
+if [[ -n "$SUCCESS_CRITERIA" ]]; then
+    CORE_ARGS+=("--success-criteria=$SUCCESS_CRITERIA")
+fi
+
+# Run the core script with the reconstructed arguments
+"$CORE_SCRIPT" "${CORE_ARGS[@]}"
 
 # AGENT_NAME and TASK_TITLE already captured above
 


### PR DESCRIPTION
## Summary
- Fixed argument duplication bug in `setup-agent-task-desktop.sh` where arguments were being passed incorrectly to the core script
- Replaced direct `$@` passing with properly reconstructed `CORE_ARGS` array
- Prevents malformed branch names and GitHub issue creation errors

## Root Cause
The desktop script was passing `"$@"` to the core script after having already parsed the arguments, but `$@` still contained all the original arguments, causing duplication.

## Solution
Built a clean `CORE_ARGS` array with only the properly formatted arguments needed by the core script.

## Test Plan
- [x] Verified the fix correctly reconstructs arguments
- [x] Checked that all argument types (required and optional) are properly passed
- [ ] Test with actual agent task creation to confirm branch names are correctly formed

Fixes #294

🤖 Generated with [Claude Code](https://claude.ai/code)