### PR TITLE
Fix Setup Script Local Variable Bug

### DIFF
--- a/agentic-development/scripts/setup-agent-task.sh
+++ b/agentic-development/scripts/setup-agent-task.sh
@@ -110,7 +110,7 @@ else
     echo ""
     
     # Check if enhanced context was provided by looking for context indicators
-    local has_context=false
+    has_context=false
     if [[ -n "$CONTEXT_FILE" && -f "$CONTEXT_FILE" ]] || [[ -n "$FILES_TO_EXAMINE" ]] || [[ -n "$SUCCESS_CRITERIA" ]]; then
         has_context=true
     fi


### PR DESCRIPTION
## Summary
- Fixed incorrect `local` variable declaration in setup-agent-task.sh:113
- Local keyword can only be used inside functions in bash
- Verified setup-agent-task-desktop.sh has no similar issues
- Both scripts now pass bash syntax validation

## Changes
- Removed `local` keyword from `has_context` variable declaration
- Changed `local has_context=false` to `has_context=false`

## Test Plan
- ✅ Validated bash syntax with `bash -n` on both setup scripts
- ✅ Both scripts pass syntax validation without errors
- ✅ No similar issues found in desktop version

## References
- Closes #315

🤖 Generated with [Claude Code](https://claude.ai/code)