### PR TITLE
Fix GitHub Actions workflow failures from merge conflict marker

### DIFF
--- a/.github/workflows/file-reference-validation.yml
+++ b/.github/workflows/file-reference-validation.yml
@@ -336,4 +336,3 @@ jobs:
           echo "✅ All file references are valid!"
           echo "📊 Coverage: ${{ needs.file-reference-validation.outputs.coverage-percentage }}%"
           echo "🔗 References: ${{ needs.file-reference-validation.outputs.total-references }}"
->>>>>>> origin/dev


### PR DESCRIPTION
## Summary
Fixed GitHub Actions workflow failures caused by dangling merge conflict marker in `.github/workflows/file-reference-validation.yml`

### Root Cause
- Merge conflict marker `>>>>>>> origin/dev` left at end of workflow file during PR #336 merge
- Caused YAML syntax errors blocking all CI/CD pipelines
- Failed workflow runs: #17267418010 and #17267417718

### Fix Applied
- Removed merge conflict marker from line 339-340
- Validated YAML syntax with Python `yaml.safe_load()` 
- Restored complete workflow functionality

### Files Modified
```diff
# .github/workflows/file-reference-validation.yml
          echo "📊 Coverage: ${{ needs.file-reference-validation.outputs.coverage-percentage }}%"
          echo "🔗 References: ${{ needs.file-reference-validation.outputs.total-references }}"
->>>>>>> origin/dev
```

### Validation Results
- ✅ YAML syntax validates successfully
- ✅ No other merge conflicts found in repository  
- ✅ All safety checks completed
- ✅ Critical infrastructure fix ready for deployment

### Impact
🚨 **CRITICAL FIX**: Restores all GitHub Actions workflows
🎯 **UNBLOCKS**: Development team can proceed with PR merges
⚡ **PRIORITY**: Infrastructure has been down since failed workflows

## Test Plan
- [x] Validate YAML syntax with Python parser
- [x] Check for additional merge conflicts (none found)
- [x] Verify git status clean after fix
- [x] Push to feature branch successfully

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>