### PR TITLE
fix: resolve GitHub Actions workflow failures from merge conflict

### DIFF
--- a/.github/workflows/file-reference-validation.yml
+++ b/.github/workflows/file-reference-validation.yml
@@ -336,4 +336,3 @@ jobs:
           echo "✅ All file references are valid!"
           echo "📊 Coverage: ${{ needs.file-reference-validation.outputs.coverage-percentage }}%"
           echo "🔗 References: ${{ needs.file-reference-validation.outputs.total-references }}"
->>>>>>> origin/dev


### PR DESCRIPTION
## Summary
Critical fix for GitHub Actions workflow failures caused by merge conflict marker in workflow file.

### Root Cause
- Merge conflict marker `>>>>>>> origin/dev` left in `.github/workflows/file-reference-validation.yml`
- Occurred during merge of PR #336 (code-review system implementation)
- YAML syntax error blocked all CI/CD pipelines

### Issues Fixed
- Failed workflow run #17267418010 (Infrastructure Validation)
- Failed workflow run #17267417718 (File Reference Validation) 
- Restored complete GitHub Actions functionality

### Technical Details
**File Modified**: `.github/workflows/file-reference-validation.yml:339`
**Change**: Removed dangling merge conflict marker
**Validation**: YAML syntax confirmed with Python `yaml.safe_load()`

### Impact
🚨 **CRITICAL**: Restores all GitHub Actions workflows
🎯 **UNBLOCKS**: Development workflows can proceed
⚡ **URGENT**: Infrastructure down until merged

### Validation Completed
- [x] YAML syntax validates successfully
- [x] No additional merge conflicts found
- [x] All safety checks passed
- [x] Ready for immediate deployment

**Branch Strategy**: Feature → dev (following CLAUDE.md safety rules)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>