### PR TITLE
fix: remove merge conflict marker from GitHub Actions workflow

### DIFF
--- a/.github/workflows/file-reference-validation.yml
+++ b/.github/workflows/file-reference-validation.yml
@@ -336,4 +336,3 @@ jobs:
           echo "✅ All file references are valid!"
           echo "📊 Coverage: ${{ needs.file-reference-validation.outputs.coverage-percentage }}%"
           echo "🔗 References: ${{ needs.file-reference-validation.outputs.total-references }}"
->>>>>>> origin/dev


### PR DESCRIPTION
## Summary
- Remove merge conflict marker `>>>>>>> origin/dev` from line 339 in `.github/workflows/file-reference-validation.yml`
- Fixes YAML parsing failure blocking all GitHub Actions workflows
- Restores CI/CD functionality after PR #363

## Test plan
- [x] YAML syntax validation passed using Python yaml parser
- [x] GitHub Actions workflows should now parse correctly
- [x] No functional changes to workflow logic

🤖 Generated with [Claude Code](https://claude.ai/code)