### PR TITLE
fix: correct JavaScript template literal syntax in GitHub Actions workflow

### DIFF
--- a/.github/workflows/file-reference-validation.yml
+++ b/.github/workflows/file-reference-validation.yml
@@ -291,7 +291,7 @@ jobs:
                 Please check the latest workflow run for updated details.`
               });
               
-              console.log(\`Updated existing issue #\${existingIssue.number}\`);
+              console.log(`Updated existing issue #${existingIssue.number}`);
             } else {
               // Create new issue
               const newIssue = await github.rest.issues.create({
@@ -302,7 +302,7 @@ jobs:
                 labels: ['automated', 'file-references', 'broken-links', 'devops']
               });
               
-              console.log(\`Created issue #\${newIssue.data.number}\`);
+              console.log(`Created issue #${newIssue.data.number}`);
             }
 
   block-merge:


### PR DESCRIPTION
## Summary
- Fixed SyntaxError in `.github/workflows/file-reference-validation.yml`
- Removed unnecessary backslash escaping from template literals in console.log statements
- Resolves 'Invalid or unexpected token' error in github-script action during issue creation

## Changes Made
- **File**: `.github/workflows/file-reference-validation.yml`
- **Lines 294 & 305**: Corrected template literal syntax by removing backslash escaping
- **Before**: `console.log(\`Updated existing issue #\${existingIssue.number}\`);`
- **After**: `console.log(`Updated existing issue #${existingIssue.number}`);`

## Test Plan
- [x] JavaScript syntax validation successful
- [x] Workflow YAML structure confirmed valid
- [x] GitHub Actions workflow shows as active
- [ ] Verify workflow runs without syntax errors in next execution

## Related Issues
Fixes #366

🤖 Generated with [Claude Code](https://claude.ai/code)