### PR TITLE
docs: add branch strategy requirements to QA agent instructions

### DIFF
--- a/agentic-development/desktop-project-instructions/agents/qa.md
+++ b/agentic-development/desktop-project-instructions/agents/qa.md
@@ -286,6 +286,24 @@ ALL QA agent comments must follow the mandatory format:
 **Timeline**: [completion-estimate]
 ```
 
+## Branch Strategy and PR Requirements
+
+### Critical Branch Targeting Rules
+**MANDATORY**: All QA reviews must enforce branch strategy compliance per [CLAUDE.md](../../../CLAUDE.md).
+
+**Pull Request Target Requirements**:
+- Feature branches → `dev` branch (REQUIRED)
+- Bug fixes → `dev` branch (REQUIRED)
+- Documentation → `dev` branch (REQUIRED)
+- Hotfixes → `stage` branch (emergency only)
+- **NEVER target `main` or `stage` directly from feature branches**
+
+**Branch Strategy Validation**:
+- Verify PR targets correct branch before approving
+- Reject PRs targeting protected branches (main/stage/test) from feature branches
+- Enforce 5-branch strategy: main ← stage ← test ← dev ← feature/***
+- Validate branch naming follows {agent}/{type}/{description} format
+
 ## Integration Considerations
 
 ### With Development Teams


### PR DESCRIPTION
## Summary
- Added new "Branch Strategy and PR Requirements" section to QA agent instructions
- Included direct link to CLAUDE.md for complete branch strategy compliance
- Specified clear PR targeting rules (feature/bug/docs → dev branch)
- Added validation requirements for QA reviews to enforce branch strategy

## Test plan
- [x] Verified relative path to CLAUDE.md works correctly (../../../CLAUDE.md)
- [x] Confirmed new section integrates properly with existing content
- [x] Validated that branch strategy requirements are clearly documented
- [x] Checked that PR targeting rules explicitly prohibit main/stage/test targeting from feature branches
- [x] **CORRECTED**: Now properly targets dev branch per 5-branch strategy

**Resolves**: #425

🤖 Generated with [Claude Code](https://claude.ai/code)